### PR TITLE
convert number to string on render, to avoid crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ export default class Calendar extends PureComponent {
                 <TouchableOpacity onPress={() => this.handleDayPress(dateNumber)}>
                     <View style={[styles.dayInner, isToday ? styles.todayDayInner : {}]}>
                         <Text style={[styles.dayText, isWeekend ? styles.dayWeekendText : {}]}>
-                            {dateNumber}
+                            {`${dateNumber}`}
                         </Text>
                     </View>
                 </TouchableOpacity>


### PR DESCRIPTION
this addresses random crashes when tapping the numeric day buttons. The error thrown is:
```
undefined is not an object (evaluating 'props[registrationName]') undefined is not an object (evaluating 'props[registrationName]')
```
described here: https://github.com/facebook/react-native/issues/12905