### PR TITLE
Style selected day on change month or year

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,11 +124,7 @@ export default class Calendar extends PureComponent {
     renderCalendarDay(index, dateNumber) {
         const weekDay = (index + this.props.weekFirstDay) % 7;
         const isWeekend = weekDay === 0 || weekDay  === 6;
-
-        const today = new Date();
-        const isToday = this.props.date.getDate() === dateNumber &&
-                        this.props.date.getMonth() === today.getMonth() &&
-                        this.props.date.getFullYear() === today.getFullYear();
+        const isToday = this.props.date.getDate() === dateNumber
 
         return (
             <View key={dateNumber} style={styles.dayOuter}>


### PR DESCRIPTION
When changing month or year, the selected day was not being styled. This caused confusion because it was not the expected behavior by most of the users. Now, the selected day will still be selected on changing months or years.