### PR TITLE
Change React.Proptypes to just PropTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # react-native-calendar
 
-This is basically an update to Nikches' React Native Calendar Component. The reason for the update is to solve the errors due to the deprecation of React.PropTypes.
-Basic usage is generally/exactly the same
+This is a minor update.
+The new feature this release adds is simply so that the calendar component can also receive a `style` props in order to customize the default styling.
 
 Calendar component for ReactNative. It is stateless component.
 
@@ -28,6 +28,7 @@ npm install --save react-native-calendar-updated
 ```javascript
 import React, { Component } from "react";
 import Calendar from "react-native-calendar-updated";
+import { StyleSheet } from "react-native";
 
 export default class CalendarTest extends Component {
     constructor(props) {
@@ -64,8 +65,15 @@ export default class CalendarTest extends Component {
                 date={this.state.date}
                 onPrevButtonPress={() => this.handlePrevButtonPress()}
                 onNextButtonPress={() => this.handleNextButtonPress()}
-                onDateSelect={(date) => this.handleDateSelect(date)} />
+                onDateSelect={(date) => this.handleDateSelect(date)}
+                style={{styles.customStyling}} />
         );
     }
 }
+
+const styles = StyleSheet.create({
+    customStyling: {
+        borderBottomWidth: 0
+    }
+})
 ```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # react-native-calendar
+
+This is basically an update to Nikches' React Native Calendar Component. The reason for the update is to solve the errors due to the deprecation of React.PropTypes.
+Basic usage is generally/exactly the same
+
 Calendar component for ReactNative. It is stateless component.
 
 ![example](calendar.png)
 
 ## install 
 ```
-npm install --save react-native-calendar-component
+npm install --save react-native-calendar-updated
 ```
 
 ## props
@@ -23,7 +27,7 @@ npm install --save react-native-calendar-component
 
 ```javascript
 import React, { Component } from "react";
-import Calendar   from "react-native-calendar-component";
+import Calendar from "react-native-calendar-updated";
 
 export default class CalendarTest extends Component {
     constructor(props) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from "react";
+import PropTypes from 'prop-types';
 
 import {
     StyleSheet,
@@ -30,13 +31,13 @@ export default class Calendar extends PureComponent {
 
     static get propTypes() {
         return {
-            date: React.PropTypes.object,
-            onDateSelect: React.PropTypes.func,
-            onPrevButtonPress: React.PropTypes.func,
-            onNextButtonPress: React.PropTypes.func,
-            dayNames: React.PropTypes.array,
-            monthNames: React.PropTypes.array,
-            weekFirstDay: React.PropTypes.number,
+            date: PropTypes.object,
+            onDateSelect: PropTypes.func,
+            onPrevButtonPress: PropTypes.func,
+            onNextButtonPress: PropTypes.func,
+            dayNames: PropTypes.array,
+            monthNames: PropTypes.array,
+            weekFirstDay: PropTypes.number,
         };
     }
 

--- a/index.js
+++ b/index.js
@@ -201,7 +201,7 @@ export default class Calendar extends PureComponent {
         }
 
         return (
-            <View style={[styles.calendar]}>
+            <View style={[styles.calendar, this.props.style]}>
                 {this.renderBar()}
                 {this.renderDayNames()}
                 {weeks}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-calendar-updated",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Calendar component for ReactNative.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,20 +1,21 @@
 {
-  "name": "react-native-calendar-component",
-  "version": "0.1.2",
+  "name": "react-native-calendar-updated",
+  "version": "1.0.0",
   "description": "Calendar component for ReactNative.",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nikches/react-native-calendar.git"
+    "url": "git+https://github.com/andela-mpitan/react-native-calendar.git"
   },
   "keywords": [
     "ReactNative",
-    "calendar"
+    "calendar",
+    "updated"
   ],
-  "author": "nikches",
+  "author": "van_paitin",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/nikches/react-native-calendar/issues"
+    "url": "https://github.com/andela-mpitan/react-native-calendar/issues"
   },
-  "homepage": "https://github.com/nikches/react-native-calendar#readme"
+  "homepage": "https://github.com/andela-mpitan/react-native-calendar#readme"
 }


### PR DESCRIPTION
The app is breaking on recent versions of React. Specifically `> 0.44`. This is due to the fact that the PropTypes library has been extracted out of the core `React` library. This PR fixes it